### PR TITLE
Add Automatic Build Workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.PAT }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./FlameCord-Proxy/bootstrap/target/FlameCord.jar
+          asset_path: ./MangoCord-Proxy/bootstrap/target/MangoCord.jar
           asset_name: MangoCord.jar
           asset_content_type: application/java-archive

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.PAT }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./MangoCord-Proxy/bootstrap/target/MangoCord.jar
+          asset_path: ./MangoCord-Proxy/bootstrap/target/Mangocord.jar
           asset_name: MangoCord.jar
           asset_content_type: application/java-archive

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,49 @@
+name: Build and Release
+
+on:
+  push:
+    tags:
+      - "[1-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Git
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+          cache: maven
+      - name: Run Build Script
+        run: sh scripts/build.sh --jar
+      - name: Build with Maven
+        run: mvn -B package --file pom.xml
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT }}
+        with:
+          tag_name: ${{ github.ref_name }}
+          release_name: "Release ${{ github.ref_name }}"
+          body: "Automatic release"
+          draft: false
+          prerelease: false
+      - name: Upload Artifact
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./FlameCord-Proxy/bootstrap/target/FlameCord.jar
+          asset_name: MangoCord.jar
+          asset_content_type: application/java-archive

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ https://discord.gg/PeS8h8eJZJ
 - /mangocord firewall <add/remove> <ip> > Firewall certain ips!
 - /bplugins > Show the plugin list!
 - /bip <player> > Show the ip and info of a player!
-- /mangocord stats > Displays flamecord stats!
+- /mangocord stats > Displays mangocord stats!
 - /mangocord help > Shows this message!
 
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@ If you suspect or confirm a possible vulnerability, let us know privately by DM.
 
 In your report, please include as much detail as possible:
 
-- The version or git sha of FlameCord you are running.
+- The version or git sha of MangoCord you are running.
 - Your operating system distribution & version.
 - Steps to reproduce.
 - Expected behavior.

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <url>https://github.com/LuciaNishimiya/MangoCord</url>
 
     <modules>
-        <module>FlameCord-Proxy</module>
+        <module>MangoCord-Proxy</module>
     </modules>
 
     <build>

--- a/scripts/applyPatches.sh
+++ b/scripts/applyPatches.sh
@@ -67,7 +67,7 @@ applyPatch BungeeCord Waterfall-Proxy HEAD
 popd
 basedir=$(dirname "$basedir")
 
-# Apply flamecord patches
+# Apply mangocord patches
 applyPatch Waterfall/Waterfall-Proxy MangoCord-Proxy HEAD
 
 enableCommitSigningIfNeeded


### PR DESCRIPTION
With this workflow, the jar should automatically build and create a release as soon as you create a new tag. 
This should make it easier to create a new release.

I also updated the name in a few places 😄 

Note: You might want to change `draft: false` to true if you want to create a custom description for every release before publishing it

And do not forget to create a token which has permissions to create a release. In order to create one, open your personal GitHub settings and go to developer settings. There you click on Personal Access Tokens and create a new Fine-Grained token (or just follow this link: https://github.com/settings/tokens?type=beta)
Give the tokens just access to this repo. As for the permissions `Contents` and `Actions` should be enough under the category `Repository permissions`.
To add the token, open the settings tab in this project and add it here:
![image](https://github.com/LuciaNishimiya/MangoCord/assets/19777054/0c83f0e7-b182-41f1-bef1-750c3dc6d045)
